### PR TITLE
Add non-codespaces warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the "ado-codespaces-code" extension will be documented in this file.
 
+## [1.1.1] - 2023-09-12
+- Add warning for non Codespace environments
+
 ## [1.1.0] - 2023-04-12
 - Credential helper for managed identities, installed at `~/azure-auth-helper`.
 - This one allows specifying custom scopes for the access token, like so:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/ado-codespaces-auth"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "engines": {
     "vscode": "^1.74.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,6 +123,21 @@ const authenticateAdo = async (context: vscode.ExtensionContext) => {
 };
 
 export async function activate(context: vscode.ExtensionContext) {
+
+  if (vscode.env.remoteName !== "codespaces") {
+    vscode.window.showWarningMessage("ADO Codespaces Auth extension is only supported in Github Codespaces", "Uninstall")
+      .then(async (data) => {
+        if (data === "Uninstall") {
+          try {
+            await vscode.commands.executeCommand("workbench.extensions.uninstallExtension", "ms-codespaces-tools.ado-codespaces-auth")
+          } catch (err) {
+            log(err || "");
+          }
+        }
+      });
+    return;
+  }
+
   await startServer();
 
   const disposable = vscode.commands.registerCommand(


### PR DESCRIPTION
We should not active extension in non Codespaces environments. This is especially important as the extension messes with home directory - which is fine on throwaway environments like Codespaces, but might not be wanted in local devboxes.