### PR TITLE
Restore logic for default scope if not provided in getAccessToken function

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   - `get-access-token` - This command will print an access token to stdout. Other tools can integrate this for getting ADO credentials, for eg, authenticating to ADO Artifact Feeds (NPM, Nuget). 
 - This extension is not recommended to be installed by itself. You should instead use the [external-repository](https://github.com/microsoft/codespace-features/tree/main/src/external-repository) and [artifacts-helper](https://github.com/microsoft/codespace-features/tree/main/src/artifacts-helper) devcontainer features which will ensure this extension is preinstalled on your Codespace with proper configuration.
 
-### New in versione 1.2
+### New in version 1.2
 - Add the `adoCodespacesAuth.tenantID` setting 
 
 ### New in version 1.1

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Azure Devops Codespaces Authentication
 
 - This VSCode extension is used for authenticating to Azure Devops in GitHub Codespaces.
-- It authenticates using in-built microsoft auth provider to authenticate to ADO using AAD login.
+- It authenticates using in-built microsoft auth provider to authenticate to ADO using Entra ID login.
 - User is prompted for login on opening a codespace with this extension installed.
+- The default is to sign in to the common Entra ID tenant. The setting `adoCodespacesAuth.tenantID` allows to specify tenant to sign in to.
 - The OAuth access token is then shared with the codespace using a credential helper which is installed at `~/ado-auth-helper`. The credential helper supports two commands
   - `get` - This command is used by git credential helper to get auth credentials for git. You can configure the helper by running `git config --global credential.helper '<absolutePathToHelper>'`.
   - `get-access-token` - This command will print an access token to stdout. Other tools can integrate this for getting ADO credentials, for eg, authenticating to ADO Artifact Feeds (NPM, Nuget). 
 - This extension is not recommended to be installed by itself. You should instead use the [external-repository](https://github.com/microsoft/codespace-features/tree/main/src/external-repository) and [artifacts-helper](https://github.com/microsoft/codespace-features/tree/main/src/artifacts-helper) devcontainer features which will ensure this extension is preinstalled on your Codespace with proper configuration.
+
+### New in versione 1.2
+- Add the `adoCodespacesAuth.tenantID` setting 
 
 ### New in version 1.1
 - Credential helper for managed identities, installed at `~/azure-auth-helper`.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,18 @@
         "command": "ado-codespaces-auth.authenticate",
         "title": "Authenticate Azure DevOps"
       }
-    ]
+    ],
+    "configuration":{
+      "type": "object",
+      "title": "Azure DevOps Codespaces Authentication",
+      "properties": {
+        "adoCodespacesAuth.tenantID": {
+          "type": "string",
+          "default": "",
+          "description": "A specific tenant to sign in to. The default is to sign in to the common tenant. Valid values are common, organizations, consumers, and tenant identifiers."
+        }
+      }
+    }
   },
   "extensionKind": [
     "workspace"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/ado-codespaces-auth"
   },
-  "version": "1.1.1",
+  "version": "1.2.0",
   "engines": {
     "vscode": "^1.74.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,8 +113,8 @@ const authenticateAdo = async (context: vscode.ExtensionContext) => {
     var scopes = ["499b84ac-1321-427f-aa17-267ca6975798/.default"];
 
     var tenantID = vscode.workspace.getConfiguration("adoCodespacesAuth").get('tenantID');
-    if (tenantID && tenantID != '') {
-      scopes.push(`VSCODE_TENANT:${tenantID}`)
+    if (tenantID && tenantID !== '') {
+      scopes.push(`VSCODE_TENANT:${tenantID}`);
     }
 
     await getAccessToken(scopes);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ const startServer = (): Promise<void> => {
         ipc.server.emit(
           socket,
           "accessToken",
-          await getAccessToken(scopes?.split(" "))
+          await getAccessToken(scopes?.split(" ") ?? [DEFAULT_ADO_SCOPE])
         );
       });
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as os from "os";
 import { v4 as uuidV4 } from "uuid";
 import { IPC } from "node-ipc";
 
+const DEFAULT_ADO_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default";
 const outputChannel = vscode.window.createOutputChannel("ADO Codespaces Auth");
 
 const authVsCodeCommand = "ado-codespaces-auth.authenticate";
@@ -110,9 +111,9 @@ const createHelperExecutable = (
 
 const authenticateAdo = async (context: vscode.ExtensionContext) => {
   try {
-    var scopes = ["499b84ac-1321-427f-aa17-267ca6975798/.default"];
+    const scopes = [DEFAULT_ADO_SCOPE];
 
-    var tenantID = vscode.workspace.getConfiguration("adoCodespacesAuth").get('tenantID');
+    const tenantID = vscode.workspace.getConfiguration("adoCodespacesAuth").get('tenantID');
     if (tenantID && tenantID !== '') {
       scopes.push(`VSCODE_TENANT:${tenantID}`);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,7 @@ const statusBarItem = vscode.window.createStatusBarItem(
 );
 
 const getAccessToken = async (
-  scopes = ["499b84ac-1321-427f-aa17-267ca6975798/.default"]
+  scopes: readonly string[]
 ) => {
   let session = await vscode.authentication.getSession("microsoft", scopes, {
     silent: true,
@@ -110,7 +110,14 @@ const createHelperExecutable = (
 
 const authenticateAdo = async (context: vscode.ExtensionContext) => {
   try {
-    await getAccessToken();
+    var scopes = ["499b84ac-1321-427f-aa17-267ca6975798/.default"];
+
+    var tenantID = vscode.workspace.getConfiguration("adoCodespacesAuth").get('tenantID');
+    if (tenantID && tenantID != '') {
+      scopes.push(`VSCODE_TENANT:${tenantID}`)
+    }
+
+    await getAccessToken(scopes);
 
     createHelperExecutable(context, "ado-auth-helper");
     createHelperExecutable(context, "azure-auth-helper");


### PR DESCRIPTION
Before this change https://github.com/microsoft/ado-codespaces-auth/pull/15, the scope of 'getAccessToken' was optional: it was initialized to the value of DEFAULT_ADO_SCOPE.
The default value was missing in the absence of a scope from the other caller via socket (IPC)